### PR TITLE
Process user data for recommendations

### DIFF
--- a/ReplicatedStorage/EventMemory.lua
+++ b/ReplicatedStorage/EventMemory.lua
@@ -1,0 +1,904 @@
+-- EventMemory.lua
+-- ═══════════════════════════════════════════════════════════════════════════════
+-- COMPREHENSIVE EVENT MEMORY & VALIDATION SYSTEM
+-- BitLife AAA-Quality Backend - Tracks EVERYTHING the player does
+-- ═══════════════════════════════════════════════════════════════════════════════
+--
+-- This system ensures:
+-- 1. Events ONLY fire based on player's ACTUAL history
+-- 2. NPCs and relationships are remembered correctly
+-- 3. Past choices affect future opportunities
+-- 4. No "phantom" events (like tax returns without work history)
+-- 5. Proper consequence chains from player decisions
+--
+-- ═══════════════════════════════════════════════════════════════════════════════
+
+local EventMemory = {}
+
+----------------------------------------------------------------------
+-- MEMORY CATEGORIES - What we track about the player
+----------------------------------------------------------------------
+
+EventMemory.Categories = {
+	-- Work/Career History
+	WORK = {
+		ever_worked = false,           -- Has EVER had any job
+		first_job_age = nil,           -- Age when first job started
+		total_jobs_held = 0,           -- Number of different jobs
+		years_employed = 0,            -- Total years with employment
+		current_job = nil,             -- Current job details
+		job_history = {},              -- List of all jobs held
+		fired_count = 0,               -- Times fired
+		quit_count = 0,                -- Times quit voluntarily
+		promotions_received = 0,       -- Total promotions
+		best_salary = 0,               -- Highest salary ever earned
+		is_entrepreneur = false,       -- Started own business
+		is_freelancer = false,         -- Works freelance
+		career_path = nil,             -- Main career path chosen
+		internships_completed = 0,     -- Number of internships
+		part_time_experience = false,  -- Worked part-time
+	},
+	
+	-- Education History
+	EDUCATION = {
+		highest_level = "none",        -- none/elementary/middle/high_school/some_college/associate/bachelor/master/doctorate
+		dropped_out = false,           -- Ever dropped out
+		dropout_level = nil,           -- What level dropped out from
+		ged_earned = false,            -- Got GED after dropping out
+		grades = "average",            -- poor/average/good/excellent
+		honor_roll = false,            -- Ever on honor roll
+		valedictorian = false,         -- Was valedictorian
+		scholarships = 0,              -- Number of scholarships
+		expelled = false,              -- Ever expelled
+		schools_attended = {},         -- List of schools
+		major = nil,                   -- College major if applicable
+		gpa = nil,                     -- GPA if tracked
+		academic_awards = {},          -- Academic achievements
+		study_abroad = false,          -- Studied abroad
+		clubs = {},                    -- School clubs joined
+		sports = {},                   -- School sports played
+	},
+	
+	-- Relationship History
+	RELATIONSHIPS = {
+		ever_dated = false,            -- Has ever dated
+		first_date_age = nil,          -- Age of first date
+		total_relationships = 0,       -- Total romantic relationships
+		current_partner = nil,         -- Current partner details
+		times_married = 0,             -- Marriage count
+		times_divorced = 0,            -- Divorce count
+		children_count = 0,            -- Number of children
+		children = {},                 -- List of children
+		cheated = false,               -- Has cheated
+		been_cheated_on = false,       -- Been cheated on
+		engagements = 0,               -- Times engaged
+		breakups = 0,                  -- Breakup count
+		widowed = false,               -- Is widowed
+		friends_made = 0,              -- Lifetime friends made
+		current_friends = {},          -- Current active friendships
+		best_friend = nil,             -- Best friend if any
+		enemies = {},                  -- People who dislike player
+		family_relationships = {},     -- Family member status
+		social_events_attended = 0,    -- Parties, gatherings, etc.
+	},
+	
+	-- Criminal History
+	CRIMINAL = {
+		ever_committed_crime = false,  -- Any criminal activity
+		crimes_committed = {},         -- List of crimes
+		times_arrested = 0,            -- Arrest count
+		times_convicted = 0,           -- Conviction count
+		prison_sentences = {},         -- Prison terms served
+		total_prison_years = 0,        -- Years in prison
+		current_status = "clean",      -- clean/wanted/imprisoned/parole
+		parole = false,                -- Currently on parole
+		probation = false,             -- Currently on probation
+		gang_member = false,           -- In a gang
+		gang_rank = nil,               -- Gang position
+		informant = false,             -- Snitched to police
+		notorious = false,             -- Famous criminal
+		reformed = false,              -- Went straight after crime
+		community_service_hours = 0,   -- Court-ordered service
+	},
+	
+	-- Financial History  
+	FINANCIAL = {
+		ever_had_money = false,        -- Has had significant money
+		highest_net_worth = 0,         -- Peak wealth
+		bankruptcies = 0,              -- Times bankrupt
+		ever_homeless = false,         -- Been homeless
+		current_debt = 0,              -- Current debt amount
+		loans_taken = 0,               -- Loans borrowed
+		loans_paid_off = 0,            -- Loans fully repaid
+		investments = {},              -- Investment history
+		properties_owned = {},         -- Real estate
+		inheritance_received = 0,      -- Money inherited
+		lottery_wins = 0,              -- Lottery winnings
+		gambling_losses = 0,           -- Total lost gambling
+		charity_donated = 0,           -- Total donated
+		taxes_paid = 0,                -- Lifetime taxes
+		filed_taxes = false,           -- Has filed taxes
+	},
+	
+	-- Health History
+	HEALTH = {
+		conditions = {},               -- Current/past health conditions
+		surgeries = {},                -- Surgeries undergone
+		hospitalizations = 0,          -- Hospital stays
+		addictions = {},               -- Current/past addictions
+		in_recovery = false,           -- Addiction recovery
+		therapy_sessions = 0,          -- Therapy attended
+		medications = {},              -- Current medications
+		disabilities = {},             -- Any disabilities
+		near_death_experiences = 0,    -- Close calls
+		fitness_level = "average",     -- sedentary/average/fit/athletic
+		diet_type = "regular",         -- regular/healthy/poor/vegan/etc
+		mental_health_issues = {},     -- Mental health history
+	},
+	
+	-- Skills & Hobbies
+	SKILLS = {
+		learned_skills = {},           -- Skills acquired
+		hobbies = {},                  -- Active hobbies
+		languages = {"English"},       -- Languages known
+		certifications = {},           -- Professional certs
+		licenses = {},                 -- Licenses held (driving, etc)
+		talents = {},                  -- Natural talents
+		awards = {},                   -- Non-academic awards
+		competitions_won = {},         -- Competition victories
+	},
+	
+	-- Life Events & Milestones
+	MILESTONES = {
+		first_kiss_age = nil,
+		first_car_age = nil,
+		first_home_age = nil,
+		graduation_ages = {},          -- When graduated each level
+		marriage_ages = {},            -- When got married
+		children_birth_ages = {},      -- When had kids
+		retirement_age = nil,          -- When retired
+		major_achievements = {},       -- Big life moments
+		traumas = {},                  -- Traumatic experiences
+		lucky_events = {},             -- Fortunate happenings
+	},
+}
+
+----------------------------------------------------------------------
+-- CORE MEMORY FUNCTIONS
+----------------------------------------------------------------------
+
+-- Initialize fresh memory for a new player
+function EventMemory.create()
+	local memory = {
+		work = {},
+		education = {},
+		relationships = {},
+		criminal = {},
+		financial = {},
+		health = {},
+		skills = {},
+		milestones = {},
+		timeline = {},    -- Chronological event log
+		flags = {},       -- Quick lookup flags
+		reputation = {},  -- How NPCs view player
+	}
+	
+	-- Deep copy defaults
+	for category, defaults in pairs(EventMemory.Categories) do
+		local catKey = string.lower(category)
+		memory[catKey] = {}
+		for key, value in pairs(defaults) do
+			if type(value) == "table" then
+				memory[catKey][key] = {}
+			else
+				memory[catKey][key] = value
+			end
+		end
+	end
+	
+	return memory
+end
+
+-- Record an event to memory
+function EventMemory.recordEvent(memory, eventType, data, age)
+	if not memory then return end
+	
+	-- Add to timeline
+	table.insert(memory.timeline, {
+		type = eventType,
+		data = data,
+		age = age,
+		timestamp = os.time(),
+	})
+	
+	-- Process by event type
+	EventMemory.processEventType(memory, eventType, data, age)
+end
+
+-- Process specific event types and update relevant memory categories
+function EventMemory.processEventType(memory, eventType, data, age)
+	local handlers = {
+		-- Work events
+		job_started = function()
+			memory.work.ever_worked = true
+			memory.work.total_jobs_held = (memory.work.total_jobs_held or 0) + 1
+			if not memory.work.first_job_age then
+				memory.work.first_job_age = age
+			end
+			memory.work.current_job = data
+			table.insert(memory.work.job_history, {
+				job = data,
+				start_age = age,
+				end_age = nil,
+			})
+			memory.flags.employed = true
+			memory.flags.has_job = true
+			memory.flags.ever_worked = true
+		end,
+		
+		job_ended = function()
+			memory.work.current_job = nil
+			if memory.work.job_history and #memory.work.job_history > 0 then
+				memory.work.job_history[#memory.work.job_history].end_age = age
+			end
+			memory.flags.employed = false
+			memory.flags.has_job = false
+		end,
+		
+		job_fired = function()
+			memory.work.fired_count = (memory.work.fired_count or 0) + 1
+			memory.flags.fired = true
+		end,
+		
+		job_quit = function()
+			memory.work.quit_count = (memory.work.quit_count or 0) + 1
+		end,
+		
+		job_promoted = function()
+			memory.work.promotions_received = (memory.work.promotions_received or 0) + 1
+			memory.flags.promoted = true
+		end,
+		
+		internship_completed = function()
+			memory.work.internships_completed = (memory.work.internships_completed or 0) + 1
+			memory.flags.internship_completed = true
+			memory.flags.intern_experience = true
+		end,
+		
+		-- Education events
+		school_started = function()
+			table.insert(memory.education.schools_attended, {
+				type = data.type,
+				name = data.name,
+				start_age = age,
+			})
+			memory.flags.in_school = true
+		end,
+		
+		school_graduated = function()
+			memory.education.highest_level = data.level
+			memory.education.graduation_ages = memory.education.graduation_ages or {}
+			table.insert(memory.education.graduation_ages, age)
+			memory.flags["graduated_" .. data.level] = true
+			
+			if data.level == "high_school" then
+				memory.flags.high_school_graduate = true
+			elseif data.level == "college" or data.level == "bachelor" then
+				memory.flags.college_graduate = true
+				memory.flags.bachelors_degree = true
+			end
+		end,
+		
+		school_dropped_out = function()
+			memory.education.dropped_out = true
+			memory.education.dropout_level = data.level
+			memory.flags.dropped_out = true
+			memory.flags["dropped_out_" .. data.level] = true
+			memory.flags.in_school = false
+		end,
+		
+		got_ged = function()
+			memory.education.ged_earned = true
+			memory.flags.ged_graduate = true
+		end,
+		
+		honor_roll = function()
+			memory.education.honor_roll = true
+			memory.flags.honor_roll = true
+			memory.flags.honors_student = true
+		end,
+		
+		-- Relationship events
+		started_dating = function()
+			memory.relationships.ever_dated = true
+			memory.relationships.total_relationships = (memory.relationships.total_relationships or 0) + 1
+			if not memory.relationships.first_date_age then
+				memory.relationships.first_date_age = age
+			end
+			memory.relationships.current_partner = data.partner
+			memory.flags.dating = true
+			memory.flags.in_relationship = true
+		end,
+		
+		broke_up = function()
+			memory.relationships.breakups = (memory.relationships.breakups or 0) + 1
+			memory.relationships.current_partner = nil
+			memory.flags.dating = false
+			memory.flags.in_relationship = false
+		end,
+		
+		got_married = function()
+			memory.relationships.times_married = (memory.relationships.times_married or 0) + 1
+			table.insert(memory.milestones.marriage_ages or {}, age)
+			memory.flags.married = true
+			memory.flags.in_relationship = true
+		end,
+		
+		got_divorced = function()
+			memory.relationships.times_divorced = (memory.relationships.times_divorced or 0) + 1
+			memory.flags.married = false
+			memory.flags.divorced = true
+		end,
+		
+		had_child = function()
+			memory.relationships.children_count = (memory.relationships.children_count or 0) + 1
+			table.insert(memory.relationships.children, {
+				name = data.name,
+				gender = data.gender,
+				birth_age = age,
+			})
+			table.insert(memory.milestones.children_birth_ages or {}, age)
+			memory.flags.parent = true
+			memory.flags.has_children = true
+		end,
+		
+		made_friend = function()
+			memory.relationships.friends_made = (memory.relationships.friends_made or 0) + 1
+			table.insert(memory.relationships.current_friends, {
+				name = data.name,
+				met_age = age,
+				relationship = data.relationship or 50,
+			})
+			memory.flags.has_friend = true
+			memory.flags.ever_had_friend = true
+		end,
+		
+		-- Criminal events
+		committed_crime = function()
+			memory.criminal.ever_committed_crime = true
+			table.insert(memory.criminal.crimes_committed, {
+				type = data.type,
+				age = age,
+				caught = data.caught or false,
+			})
+			memory.flags.criminal = true
+			memory.flags.committed_crime = true
+		end,
+		
+		arrested = function()
+			memory.criminal.times_arrested = (memory.criminal.times_arrested or 0) + 1
+			memory.flags.arrested = true
+			memory.flags.criminal_record = true
+		end,
+		
+		went_to_prison = function()
+			table.insert(memory.criminal.prison_sentences, {
+				start_age = age,
+				duration = data.years,
+				crime = data.crime,
+			})
+			memory.criminal.current_status = "imprisoned"
+			memory.flags.in_prison = true
+		end,
+		
+		released_from_prison = function()
+			memory.criminal.current_status = "released"
+			memory.flags.in_prison = false
+			memory.flags.ex_convict = true
+			memory.flags.just_released = true
+		end,
+		
+		-- Financial events
+		paid_taxes = function()
+			memory.financial.filed_taxes = true
+			memory.financial.taxes_paid = (memory.financial.taxes_paid or 0) + (data.amount or 0)
+			memory.flags.taxpayer = true
+		end,
+		
+		went_bankrupt = function()
+			memory.financial.bankruptcies = (memory.financial.bankruptcies or 0) + 1
+			memory.flags.bankrupt = true
+		end,
+		
+		became_homeless = function()
+			memory.financial.ever_homeless = true
+			memory.flags.homeless = true
+		end,
+		
+		bought_property = function()
+			table.insert(memory.financial.properties_owned, {
+				type = data.type,
+				value = data.value,
+				age = age,
+			})
+			memory.flags.property_owner = true
+			memory.flags.homeowner = true
+		end,
+		
+		received_inheritance = function()
+			memory.financial.inheritance_received = (memory.financial.inheritance_received or 0) + (data.amount or 0)
+			memory.flags.inherited = true
+		end,
+		
+		-- Health events
+		diagnosed = function()
+			table.insert(memory.health.conditions, {
+				condition = data.condition,
+				diagnosed_age = age,
+				severity = data.severity,
+			})
+			memory.flags["has_" .. string.gsub(string.lower(data.condition), " ", "_")] = true
+		end,
+		
+		addiction_started = function()
+			table.insert(memory.health.addictions, {
+				type = data.type,
+				started_age = age,
+				active = true,
+			})
+			memory.flags.addict = true
+			memory.flags[data.type .. "_addiction"] = true
+		end,
+		
+		addiction_recovery = function()
+			memory.health.in_recovery = true
+			memory.flags.in_recovery = true
+			-- Mark addiction as inactive
+			for _, addiction in ipairs(memory.health.addictions) do
+				if addiction.type == data.type then
+					addiction.active = false
+				end
+			end
+		end,
+		
+		-- Skill events
+		learned_skill = function()
+			table.insert(memory.skills.learned_skills, {
+				skill = data.skill,
+				level = data.level or 1,
+				learned_age = age,
+			})
+			memory.flags["knows_" .. string.gsub(string.lower(data.skill), " ", "_")] = true
+		end,
+		
+		got_license = function()
+			table.insert(memory.skills.licenses, {
+				type = data.type,
+				age = age,
+			})
+			memory.flags["has_" .. data.type .. "_license"] = true
+			if data.type == "drivers" or data.type == "driving" then
+				memory.flags.has_license = true
+				memory.flags.can_drive = true
+			end
+		end,
+	}
+	
+	local handler = handlers[eventType]
+	if handler then
+		handler()
+	end
+end
+
+----------------------------------------------------------------------
+-- VALIDATION FUNCTIONS - Check if events can fire
+----------------------------------------------------------------------
+
+-- Check if player has EVER worked
+function EventMemory.hasEverWorked(memory)
+	if not memory then return false end
+	return memory.work and memory.work.ever_worked == true
+end
+
+-- Check if player is CURRENTLY employed
+function EventMemory.isCurrentlyEmployed(memory)
+	if not memory then return false end
+	return memory.work and memory.work.current_job ~= nil
+end
+
+-- Check if player has specific education level
+function EventMemory.hasEducation(memory, level)
+	if not memory or not memory.education then return false end
+	
+	local levels = {
+		none = 0,
+		elementary = 1,
+		middle = 2,
+		high_school = 3,
+		some_college = 4,
+		associate = 5,
+		bachelor = 6,
+		master = 7,
+		doctorate = 8,
+	}
+	
+	local playerLevel = levels[memory.education.highest_level or "none"] or 0
+	local requiredLevel = levels[level] or 0
+	
+	return playerLevel >= requiredLevel
+end
+
+-- Check if player dropped out
+function EventMemory.hasDroppedOut(memory)
+	if not memory or not memory.education then return false end
+	return memory.education.dropped_out == true
+end
+
+-- Check if player has filed taxes (requires work history)
+function EventMemory.canFileTaxes(memory)
+	if not memory then return false end
+	return memory.financial and memory.financial.filed_taxes == true or
+		(memory.work and memory.work.ever_worked == true)
+end
+
+-- Check if player has any friends
+function EventMemory.hasFriends(memory)
+	if not memory or not memory.relationships then return false end
+	return memory.relationships.current_friends and #memory.relationships.current_friends > 0
+end
+
+-- Get a friend's name (returns nil if no friends)
+function EventMemory.getFriendName(memory)
+	if not EventMemory.hasFriends(memory) then return nil end
+	local friends = memory.relationships.current_friends
+	local friend = friends[math.random(#friends)]
+	return friend.name
+end
+
+-- Check if player has romantic partner
+function EventMemory.hasPartner(memory)
+	if not memory or not memory.relationships then return false end
+	return memory.relationships.current_partner ~= nil
+end
+
+-- Check if player has criminal record
+function EventMemory.hasCriminalRecord(memory)
+	if not memory or not memory.criminal then return false end
+	return memory.criminal.ever_committed_crime == true
+end
+
+-- Check if player is in prison
+function EventMemory.isInPrison(memory)
+	if not memory or not memory.criminal then return false end
+	return memory.criminal.current_status == "imprisoned"
+end
+
+-- Check if player has specific skill
+function EventMemory.hasSkill(memory, skillName)
+	if not memory or not memory.skills then return false end
+	for _, skill in ipairs(memory.skills.learned_skills or {}) do
+		if string.lower(skill.skill) == string.lower(skillName) then
+			return true
+		end
+	end
+	return false
+end
+
+-- Check if player has specific license
+function EventMemory.hasLicense(memory, licenseType)
+	if not memory or not memory.skills then return false end
+	for _, license in ipairs(memory.skills.licenses or {}) do
+		if string.lower(license.type) == string.lower(licenseType) then
+			return true
+		end
+	end
+	return false
+end
+
+-- Check if player can afford something
+function EventMemory.canAfford(memory, amount, currentMoney)
+	return (currentMoney or 0) >= amount
+end
+
+-- Check if player has health condition
+function EventMemory.hasCondition(memory, condition)
+	if not memory or not memory.health then return false end
+	for _, cond in ipairs(memory.health.conditions or {}) do
+		if string.lower(cond.condition) == string.lower(condition) then
+			return true
+		end
+	end
+	return false
+end
+
+----------------------------------------------------------------------
+-- FLAG SYNCHRONIZATION - Sync memory with state flags
+----------------------------------------------------------------------
+
+-- Get all flags that should be set based on memory
+function EventMemory.getMemoryFlags(memory)
+	if not memory then return {} end
+	
+	local flags = {}
+	
+	-- Work flags
+	if memory.work then
+		if memory.work.ever_worked then
+			flags.ever_worked = true
+			flags.has_work_history = true
+		end
+		if memory.work.current_job then
+			flags.employed = true
+			flags.has_job = true
+		end
+		if memory.work.promotions_received and memory.work.promotions_received > 0 then
+			flags.promoted = true
+		end
+		if memory.work.is_entrepreneur then
+			flags.entrepreneur = true
+		end
+		if memory.work.internships_completed and memory.work.internships_completed > 0 then
+			flags.internship_completed = true
+			flags.intern_experience = true
+		end
+	end
+	
+	-- Education flags
+	if memory.education then
+		if memory.education.highest_level == "high_school" then
+			flags.high_school_graduate = true
+		elseif memory.education.highest_level == "bachelor" or memory.education.highest_level == "college" then
+			flags.college_graduate = true
+			flags.bachelors_degree = true
+			flags.high_school_graduate = true
+		elseif memory.education.highest_level == "master" then
+			flags.masters_degree = true
+			flags.college_graduate = true
+			flags.high_school_graduate = true
+		elseif memory.education.highest_level == "doctorate" then
+			flags.doctorate = true
+			flags.phd = true
+			flags.masters_degree = true
+			flags.college_graduate = true
+			flags.high_school_graduate = true
+		end
+		
+		if memory.education.dropped_out then
+			flags.dropped_out = true
+			if memory.education.dropout_level == "high_school" then
+				flags.high_school_dropout = true
+			end
+		end
+		
+		if memory.education.ged_earned then
+			flags.ged_graduate = true
+		end
+		
+		if memory.education.honor_roll then
+			flags.honor_roll = true
+			flags.honors_student = true
+		end
+	end
+	
+	-- Relationship flags
+	if memory.relationships then
+		if memory.relationships.current_partner then
+			flags.in_relationship = true
+			flags.dating = true
+		end
+		if memory.relationships.times_married and memory.relationships.times_married > 0 then
+			if memory.relationships.times_divorced < memory.relationships.times_married then
+				flags.married = true
+			end
+		end
+		if memory.relationships.children_count and memory.relationships.children_count > 0 then
+			flags.parent = true
+			flags.has_children = true
+		end
+		if memory.relationships.current_friends and #memory.relationships.current_friends > 0 then
+			flags.has_friend = true
+		end
+		if memory.relationships.friends_made and memory.relationships.friends_made > 0 then
+			flags.ever_had_friend = true
+		end
+	end
+	
+	-- Criminal flags
+	if memory.criminal then
+		if memory.criminal.ever_committed_crime then
+			flags.criminal = true
+		end
+		if memory.criminal.current_status == "imprisoned" then
+			flags.in_prison = true
+		end
+		if memory.criminal.times_arrested and memory.criminal.times_arrested > 0 then
+			flags.criminal_record = true
+		end
+		if memory.criminal.reformed then
+			flags.going_straight = true
+		end
+	end
+	
+	-- Financial flags
+	if memory.financial then
+		if memory.financial.filed_taxes then
+			flags.taxpayer = true
+		end
+		if memory.financial.properties_owned and #memory.financial.properties_owned > 0 then
+			flags.property_owner = true
+			flags.homeowner = true
+		end
+		if memory.financial.ever_homeless then
+			flags.experienced_homelessness = true
+		end
+	end
+	
+	return flags
+end
+
+-- Sync memory state with LifeState flags
+function EventMemory.syncToState(memory, state)
+	if not memory or not state then return end
+	
+	local memoryFlags = EventMemory.getMemoryFlags(memory)
+	state.Flags = state.Flags or {}
+	
+	for flag, value in pairs(memoryFlags) do
+		state.Flags[flag] = value
+	end
+end
+
+----------------------------------------------------------------------
+-- COMPREHENSIVE EVENT VALIDATION
+----------------------------------------------------------------------
+
+-- Master validation function - checks if an event can fire
+function EventMemory.validateEvent(eventDef, state, memory)
+	local result = { valid = true, reasons = {} }
+	
+	-- If no memory, fall back to basic flag checking
+	if not memory then
+		return result
+	end
+	
+	-- Check work-related requirements
+	if eventDef.requiresWorkHistory then
+		if not EventMemory.hasEverWorked(memory) then
+			result.valid = false
+			table.insert(result.reasons, "Requires work history")
+		end
+	end
+	
+	if eventDef.requiresCurrentJob then
+		if not EventMemory.isCurrentlyEmployed(memory) then
+			result.valid = false
+			table.insert(result.reasons, "Requires current employment")
+		end
+	end
+	
+	-- Check education requirements
+	if eventDef.requiresEducation then
+		if not EventMemory.hasEducation(memory, eventDef.requiresEducation) then
+			result.valid = false
+			table.insert(result.reasons, "Requires " .. eventDef.requiresEducation .. " education")
+		end
+	end
+	
+	-- Check if requires NOT being a dropout
+	if eventDef.blocksDropout then
+		if EventMemory.hasDroppedOut(memory) then
+			result.valid = false
+			table.insert(result.reasons, "Blocked for dropouts")
+		end
+	end
+	
+	-- Check tax-related requirements
+	if eventDef.requiresTaxHistory then
+		if not EventMemory.canFileTaxes(memory) then
+			result.valid = false
+			table.insert(result.reasons, "Requires tax/work history")
+		end
+	end
+	
+	-- Check friendship requirements
+	if eventDef.requiresFriends then
+		if not EventMemory.hasFriends(memory) then
+			result.valid = false
+			table.insert(result.reasons, "Requires friends")
+		end
+	end
+	
+	-- Check relationship requirements
+	if eventDef.requiresPartner then
+		if not EventMemory.hasPartner(memory) then
+			result.valid = false
+			table.insert(result.reasons, "Requires romantic partner")
+		end
+	end
+	
+	-- Check criminal history
+	if eventDef.requiresCriminalHistory then
+		if not EventMemory.hasCriminalRecord(memory) then
+			result.valid = false
+			table.insert(result.reasons, "Requires criminal history")
+		end
+	end
+	
+	if eventDef.blocksIfCriminal then
+		if EventMemory.hasCriminalRecord(memory) then
+			result.valid = false
+			table.insert(result.reasons, "Blocked by criminal record")
+		end
+	end
+	
+	-- Check skill requirements
+	if eventDef.requiresSkill then
+		if not EventMemory.hasSkill(memory, eventDef.requiresSkill) then
+			result.valid = false
+			table.insert(result.reasons, "Requires skill: " .. eventDef.requiresSkill)
+		end
+	end
+	
+	-- Check license requirements
+	if eventDef.requiresLicense then
+		if not EventMemory.hasLicense(memory, eventDef.requiresLicense) then
+			result.valid = false
+			table.insert(result.reasons, "Requires license: " .. eventDef.requiresLicense)
+		end
+	end
+	
+	return result
+end
+
+----------------------------------------------------------------------
+-- UTILITY FUNCTIONS
+----------------------------------------------------------------------
+
+-- Get a summary of player's life history
+function EventMemory.getLifeSummary(memory)
+	if not memory then return {} end
+	
+	return {
+		hasWorked = EventMemory.hasEverWorked(memory),
+		isEmployed = EventMemory.isCurrentlyEmployed(memory),
+		jobCount = memory.work and memory.work.total_jobs_held or 0,
+		education = memory.education and memory.education.highest_level or "none",
+		isDropout = EventMemory.hasDroppedOut(memory),
+		hasFriends = EventMemory.hasFriends(memory),
+		friendCount = memory.relationships and #(memory.relationships.current_friends or {}) or 0,
+		hasPartner = EventMemory.hasPartner(memory),
+		isMarried = memory.relationships and memory.relationships.times_married and memory.relationships.times_married > 0 and 
+			(memory.relationships.times_divorced or 0) < memory.relationships.times_married,
+		childCount = memory.relationships and memory.relationships.children_count or 0,
+		hasCriminalRecord = EventMemory.hasCriminalRecord(memory),
+		isInPrison = EventMemory.isInPrison(memory),
+		everBankrupt = memory.financial and (memory.financial.bankruptcies or 0) > 0,
+		everHomeless = memory.financial and memory.financial.ever_homeless or false,
+	}
+end
+
+-- Serialize memory for saving
+function EventMemory.serialize(memory)
+	-- Deep copy to avoid references
+	local function deepCopy(orig)
+		local copy
+		if type(orig) == 'table' then
+			copy = {}
+			for k, v in pairs(orig) do
+				copy[k] = deepCopy(v)
+			end
+		else
+			copy = orig
+		end
+		return copy
+	end
+	return deepCopy(memory)
+end
+
+-- Deserialize saved memory
+function EventMemory.deserialize(data)
+	if not data then return EventMemory.create() end
+	return data
+end
+
+return EventMemory

--- a/ReplicatedStorage/EventRunner.lua
+++ b/ReplicatedStorage/EventRunner.lua
@@ -334,6 +334,11 @@ local function getYearRecap(state: LifeState): string?
 	local flags = state.Flags or {}
 	local age = state.Age or 0
 	local lifeStage = getLifeStage(age)
+	
+	-- Check if player has EVER worked (important for narrative accuracy)
+	local hasEverWorked = flags.employed or flags.has_job or flags.career_starter 
+		or flags.ever_worked or flags.first_job or flags.good_worker 
+		or flags.worked_parttime or flags.intern_experience or flags.internship_completed
 
 	-- Prioritize special career paths over life stage
 	local bucket: string
@@ -353,7 +358,8 @@ local function getYearRecap(state: LifeState): string?
 		bucket = "romantic_path"
 	elseif flags.millionaire or flags.billionaire or flags.tech_billionaire then
 		bucket = "wealthy_path"
-	elseif flags.bankrupt or flags.homeless or flags.unemployed then
+	elseif flags.bankrupt or flags.homeless or flags.unemployed or (lifeStage == "adult" and not hasEverWorked) then
+		-- Include adults who never worked in struggling_path
 		bucket = "struggling_path"
 	else
 		bucket = lifeStage

--- a/ReplicatedStorage/LifeEvents/middle_aged_36_55.lua
+++ b/ReplicatedStorage/LifeEvents/middle_aged_36_55.lua
@@ -34,6 +34,31 @@ local function getFriendName(state)
 	return randomFirstName()
 end
 
+-- Returns actual friend name or nil if no friend exists
+-- Use this for events that REQUIRE an existing relationship
+local function getActualFriendName(state)
+	if not state then return nil end
+	local relationships = state.Relationships or {}
+	for _, rel in pairs(relationships) do
+		if rel.type == "friend" or rel.category == "friends" then
+			return rel.name
+		end
+	end
+	return nil
+end
+
+-- Check if player has any actual relationships of a given type
+local function hasRelationshipOfType(state, relType)
+	if not state then return false end
+	local relationships = state.Relationships or {}
+	for _, rel in pairs(relationships) do
+		if rel.type == relType or rel.category == relType then
+			return true
+		end
+	end
+	return false
+end
+
 local module = {}
 
 module.events = {
@@ -657,6 +682,9 @@ module.events = {
 		weight = 20, cooldown = 4,
 		emoji = "👋", title = "Reconnecting with Old Friends",
 		category = "social",
+		-- This event introduces a NEW old acquaintance, so random name is appropriate
+		-- But add a flag so player has some social history
+		requiresAnyFlag = {"ever_had_friend", "college_graduate", "high_school_diploma", "social_butterfly", "had_childhood_friend"},
 		getDynamicData = function()
 			return { friendName = randomFirstName() }
 		end,

--- a/ReplicatedStorage/LifeEvents/middle_aged_36_55.lua
+++ b/ReplicatedStorage/LifeEvents/middle_aged_36_55.lua
@@ -565,6 +565,7 @@ module.events = {
 		weight = 35, oneTime = true,
 		emoji = "📊", title = "Career Plateau",
 		category = "career",
+		requiresFlag = "employed", -- CRITICAL: Must have a career to plateau!
 		text = "You've been at the same level for years. Is this it? Have you peaked?",
 		choices = {
 			{ text = "🚀 Push for promotion", effects = { Smarts = 6, Happiness = 4, Money = 5000 }, resultText = "Extra effort paid off! Moving up!", setFlag = "ambitious" },
@@ -630,6 +631,7 @@ module.events = {
 		weight = 30, oneTime = true,
 		emoji = "💰", title = "Peak Earning Years",
 		category = "career",
+		requiresFlag = "employed", -- CRITICAL: Must have income to be in peak earning years!
 		text = "You're in your prime earning years. Salary is highest it's ever been!",
 		choices = {
 			{ text = "💵 Max retirement savings", effects = { Money = 20000, Happiness = 4 }, resultText = "401k maxed! Future you says thanks!", setFlag = "retirement_saver" },
@@ -645,6 +647,7 @@ module.events = {
 		weight = 25, cooldown = 4,
 		emoji = "🎓", title = "Mentoring the Next Generation",
 		category = "career",
+		requiresFlag = "employed", -- CRITICAL: Must be working to mentor at work!
 		getDynamicData = function()
 			return { menteeName = randomFirstName() }
 		end,

--- a/ReplicatedStorage/LifeEvents/relationships.lua
+++ b/ReplicatedStorage/LifeEvents/relationships.lua
@@ -34,6 +34,31 @@ local function getFriendName(state)
 	return randomFirstName()
 end
 
+-- Returns actual friend name or nil if no friend exists
+-- Use this for events that REQUIRE an existing relationship
+local function getActualFriendName(state)
+	if not state then return nil end
+	local relationships = state.Relationships or {}
+	for _, rel in pairs(relationships) do
+		if rel.type == "friend" or rel.category == "friends" then
+			return rel.name
+		end
+	end
+	return nil
+end
+
+-- Check if player has ACTUAL friends in relationships (not just flags)
+local function hasActualFriend(state)
+	if not state then return false end
+	local relationships = state.Relationships or {}
+	for _, rel in pairs(relationships) do
+		if rel.type == "friend" or rel.category == "friends" then
+			return true
+		end
+	end
+	return false
+end
+
 local module = {}
 
 module.events = {
@@ -266,14 +291,15 @@ module.events = {
 		weight = 20, cooldown = 3,
 		emoji = "🆘", title = "Friend in Need",
 		category = "social",
-		-- CRITICAL: Only fire if player actually has friends!
+		-- CRITICAL: Only fire if player has ACTUAL friends in Relationships table!
 		requires = function(state)
-			return hasFriend(state)
+			return hasActualFriend(state) -- Must have real friend in relationships, not just flags
 		end,
-		requiresAnyFlag = {"has_friend", "has_best_friend", "social_butterfly", "friendly"},
 		getDynamicData = function(state)
 			-- Use actual friend name from relationships
-			return { friendName = getFriendName(state) }
+			local name = getActualFriendName(state)
+			if not name then return nil end -- Prevent event from firing with nil data
+			return { friendName = name }
 		end,
 		text = "%friendName% needs help. They're going through a tough time.",
 		choices = {
@@ -289,14 +315,15 @@ module.events = {
 		weight = 15, cooldown = 5,
 		emoji = "💔", title = "Friend Betrayal",
 		category = "social",
-		-- CRITICAL: Only fire if player actually has friends!
+		-- CRITICAL: Only fire if player has ACTUAL friends in Relationships table!
 		requires = function(state)
-			return hasFriend(state)
+			return hasActualFriend(state) -- Must have real friend in relationships, not just flags
 		end,
-		requiresAnyFlag = {"has_friend", "has_best_friend", "social_butterfly", "friendly"},
 		getDynamicData = function(state)
 			-- Use actual friend name from relationships
-			return { friendName = getFriendName(state) }
+			local name = getActualFriendName(state)
+			if not name then return nil end -- Prevent event from firing with nil data
+			return { friendName = name }
 		end,
 		text = "%friendName% betrayed your trust. They shared your secrets.",
 		choices = {
@@ -312,14 +339,15 @@ module.events = {
 		weight = 15, cooldown = 3,
 		emoji = "☠️", title = "Toxic Friend",
 		category = "social",
-		-- CRITICAL: Only fire if player actually has friends!
+		-- CRITICAL: Only fire if player has ACTUAL friends in Relationships table!
 		requires = function(state)
-			return hasFriend(state)
+			return hasActualFriend(state) -- Must have real friend in relationships, not just flags
 		end,
-		requiresAnyFlag = {"has_friend", "has_best_friend", "social_butterfly", "friendly"},
 		getDynamicData = function(state)
 			-- Use actual friend name from relationships
-			return { friendName = getFriendName(state) }
+			local name = getActualFriendName(state)
+			if not name then return nil end -- Prevent event from firing with nil data
+			return { friendName = name }
 		end,
 		text = "%friendName% has become toxic. Always negative, always drama.",
 		choices = {

--- a/ReplicatedStorage/LifeEvents/senior_55_plus.lua
+++ b/ReplicatedStorage/LifeEvents/senior_55_plus.lua
@@ -34,6 +34,31 @@ local function getFriendName(state)
 	return randomFirstName()
 end
 
+-- Returns actual friend name or nil if no friend exists
+-- Use this for events that REQUIRE an existing relationship
+local function getActualFriendName(state)
+	if not state then return nil end
+	local relationships = state.Relationships or {}
+	for _, rel in pairs(relationships) do
+		if rel.type == "friend" or rel.category == "friends" then
+			return rel.name
+		end
+	end
+	return nil
+end
+
+-- Check if player has any actual relationships of a given type
+local function hasRelationshipOfType(state, relType)
+	if not state then return false end
+	local relationships = state.Relationships or {}
+	for _, rel in pairs(relationships) do
+		if rel.type == relType or rel.category == relType then
+			return true
+		end
+	end
+	return false
+end
+
 local module = {}
 
 module.events = {
@@ -721,6 +746,8 @@ module.events = {
 		weight = 25, cooldown = 3,
 		emoji = "🕊️", title = "Losing Peers",
 		category = "social",
+		-- This event implies the player HAD friends at some point
+		requiresAnyFlag = {"ever_had_friend", "social_butterfly", "had_childhood_friend", "has_friend", "had_college_friends"},
 		getDynamicData = function()
 			return { friendName = randomFirstName() }
 		end,

--- a/ReplicatedStorage/LifeEvents/senior_55_plus.lua
+++ b/ReplicatedStorage/LifeEvents/senior_55_plus.lua
@@ -154,6 +154,15 @@ module.events = {
 		weight = 50, oneTime = true,
 		emoji = "💵", title = "Social Security Decision",
 		category = "career",
+		-- CRITICAL: Must have worked at some point to qualify for Social Security!
+		requiresAnyFlag = {"employed", "has_job", "career_starter", "ever_worked", "first_job", "retired", "good_worker", "worked_parttime"},
+		requires = function(state)
+			local flags = state.Flags or {}
+			-- Must have some work history
+			return flags.employed or flags.has_job or flags.career_starter 
+				or flags.ever_worked or flags.first_job or flags.retired
+				or flags.good_worker or flags.worked_parttime or flags.intern_experience
+		end,
 		getDynamicData = function()
 			local earlyAmount = math.random(1800, 2200)
 			local fullAmount = math.random(2400, 2900)

--- a/ReplicatedStorage/LifeEvents/teen_13_17.lua
+++ b/ReplicatedStorage/LifeEvents/teen_13_17.lua
@@ -273,10 +273,10 @@ module.events = {
 		category = "family",
 		text = "The big day! Your driving test is TODAY! How do you feel going in?",
 		choices = {
-			{ text = "😎 Super confident", effects = { Happiness = 15, Smarts = 2 }, resultText = "PASSED! Your confidence showed! FREEDOM is yours!", setFlag = "can_drive" },
+			{ text = "😎 Super confident", effects = { Happiness = 15, Smarts = 2 }, resultText = "PASSED! Your confidence showed! FREEDOM is yours!", setFlag = "has_license" },
 			{ text = "😰 Really nervous", effects = { Happiness = -8 }, resultText = "Nerves got you. Failed parallel parking. Reschedule..." },
-			{ text = "🧘 Stay calm and focused", effects = { Happiness = 12, Smarts = 5 }, resultText = "PERFECT SCORE! Calm and collected wins the day!", setFlags = {"can_drive", "perfect_driver"} },
-			{ text = "🤞 Just hope for the best", effects = { Happiness = 6 }, resultText = "Barely passed! Made some mistakes but you're legal! A pass is a pass!", setFlag = "can_drive" },
+			{ text = "🧘 Stay calm and focused", effects = { Happiness = 12, Smarts = 5 }, resultText = "PERFECT SCORE! Calm and collected wins the day!", setFlags = {"has_license", "perfect_driver"} },
+			{ text = "🤞 Just hope for the best", effects = { Happiness = 6 }, resultText = "Barely passed! Made some mistakes but you're legal! A pass is a pass!", setFlag = "has_license" },
 		},
 	},
 	
@@ -285,7 +285,7 @@ module.events = {
 		minAge = 15, maxAge = 17,
 		weight = 40, oneTime = true,
 		emoji = "💼", title = "First Part-Time Job!",
-		category = "career",
+		category = "work",
 		getDynamicData = function()
 			local jobs = {"fast food worker", "retail associate", "movie theater attendant", "grocery bagger", "lifeguard", "tutor", "babysitter", "lawn care"}
 			local wage = math.random(10, 15)
@@ -540,7 +540,7 @@ module.events = {
 		weight = 35, cooldown = 2,
 		requiresFlag = "has_job",
 		emoji = "☀️", title = "Summer Work!",
-		category = "career",
+		category = "work",
 		text = "Summer break means more hours at your job! Time to grind!",
 		choices = {
 			{ text = "💪 Work full time!", effects = { Money = 800, Health = -4, Happiness = 2 }, resultText = "Bank account growing! But no vacation." },
@@ -573,7 +573,7 @@ module.events = {
 		id = "m_car_first",
 		minAge = 16, maxAge = 17,
 		weight = 30, oneTime = true,
-		requiresFlag = "can_drive",
+		requiresFlag = "has_license",
 		emoji = "🚗", title = "First Car!",
 		category = "family",
 		getDynamicData = function()
@@ -669,7 +669,7 @@ module.events = {
 		minAge = 16, maxAge = 17,
 		weight = 25, oneTime = true,
 		emoji = "💼", title = "High School Internship!",
-		category = "career",
+		category = "work",
 		getDynamicData = function()
 			local fields = {"tech company", "law firm", "hospital", "design studio", "research lab", "local business"}
 			return { field = fields[math.random(#fields)] }

--- a/ReplicatedStorage/LifeEvents/wealth.lua
+++ b/ReplicatedStorage/LifeEvents/wealth.lua
@@ -44,6 +44,8 @@ module.events = {
 		weight = 20, oneTime = true,
 		emoji = "💵", title = "First Paycheck!",
 		category = "work",
+		-- CRITICAL: Must have a job to get a paycheck!
+		requiresFlag = "has_job",
 		getDynamicData = function()
 			local amounts = {300, 400, 500, 600}
 			return { amount = amounts[math.random(#amounts)] }

--- a/ReplicatedStorage/LifeEvents/young_adult_18_35.lua
+++ b/ReplicatedStorage/LifeEvents/young_adult_18_35.lua
@@ -68,9 +68,23 @@ module.events = {
 	{
 		id = "m_college_start",
 		minAge = 18, maxAge = 18,
-		weight = 90, milestone = true, oneTime = true,
+		weight = 90, milestone = false, oneTime = true, -- NOT a milestone - requires prerequisites!
 		emoji = "🎓", title = "Starting College!",
 		category = "school",
+		-- CRITICAL: Must have graduated high school (or GED) AND been accepted to college
+		requiresAnyFlag = {"high_school_graduate", "ged_graduate", "college_accepted", "scholarship"},
+		-- Block dropouts without GED and those already in college
+		blockIfFlag = "college_student",
+		-- Additional validation
+		requires = function(state)
+			local flags = state.Flags or {}
+			-- Must have completed high school education
+			if flags.high_school_dropout and not flags.ged_graduate then
+				return false
+			end
+			-- Must have high school diploma or equivalent
+			return flags.high_school_graduate or flags.ged_graduate
+		end,
 		getDynamicData = function()
 			local dorms = {"ancient dorm with no AC", "modern suite-style living", "party dorm", "quiet study dorm", "themed living community"}
 			local majors = {"Undeclared", "Pre-Med", "Engineering", "Business", "Liberal Arts", "Computer Science", "Psychology", "Communications"}
@@ -1051,23 +1065,69 @@ module.events = {
 		},
 	},
 	
+	-- ═══════════════════════════════════════════════════════════════
+	-- WINDFALL EVENTS - Split by source type for proper validation
+	-- ═══════════════════════════════════════════════════════════════
+	
 	{
-		id = "m_unexpected_money",
-		minAge = 22, maxAge = 35,
-		weight = 15, cooldown = 3,
-		emoji = "💰", title = "Unexpected Money!",
+		id = "m_work_bonus",
+		minAge = 22, maxAge = 60,
+		weight = 20, cooldown = 2,
+		emoji = "💰", title = "Work Bonus!",
 		category = "career",
+		requiresFlag = "employed", -- CRITICAL: Must have job to get bonus
 		getDynamicData = function()
-			local sources = {"inheritance", "tax refund", "bonus", "winning scratch-off", "old savings you forgot about", "returned security deposit"}
-			local amount = math.random(1000, 20000)
+			local amount = math.random(2000, 15000)
+			return { amount = amount }
+		end,
+		text = "Your employer gave you a $%amount% bonus! All that hard work paid off!",
+		choices = {
+			{ text = "💰 Save it all", effects = { Money = 10000, Happiness = 4, Smarts = 3 }, resultText = "Future you will thank present you!", setFlag = "saver" },
+			{ text = "💸 Treat yourself!", effects = { Money = 4000, Happiness = 10 }, resultText = "You earned it! Time to celebrate!" },
+			{ text = "📈 Invest it", effects = { Money = 7000, Smarts = 5 }, resultText = "Making money work for you!", setFlag = "investor" },
+			{ text = "💳 Pay off debt", effects = { Money = 2000, Happiness = 6, Smarts = 4 }, resultText = "Responsible choice!", setFlag = "financially_responsible" },
+		},
+	},
+	
+	{
+		id = "m_tax_refund",
+		minAge = 19, maxAge = 65,
+		weight = 15, cooldown = 3,
+		emoji = "💵", title = "Tax Refund!",
+		category = "career",
+		-- CRITICAL: Must have worked at some point to get a tax refund
+		requiresAnyFlag = {"employed", "has_job", "career_starter", "ever_worked", "first_job", "good_worker", "worked_parttime"},
+		getDynamicData = function()
+			local amount = math.random(500, 5000)
+			return { amount = amount }
+		end,
+		text = "Tax season! You're getting a $%amount% refund!",
+		choices = {
+			{ text = "💰 Straight to savings", effects = { Money = 3000, Happiness = 4, Smarts = 3 }, resultText = "Smart choice! Building that emergency fund!", setFlag = "saver" },
+			{ text = "💸 Splurge time!", effects = { Money = 1000, Happiness = 8 }, resultText = "Tax return = shopping spree!" },
+			{ text = "📈 Invest in retirement", effects = { Money = 2500, Smarts = 5 }, resultText = "IRA contribution! Future you is grateful!", setFlag = "retirement_saver" },
+			{ text = "💳 Clear some debt", effects = { Money = 1500, Happiness = 5, Smarts = 3 }, resultText = "Paying down that credit card!", setFlag = "financially_responsible" },
+		},
+	},
+	
+	{
+		id = "m_unexpected_windfall",
+		minAge = 18, maxAge = 70,
+		weight = 10, cooldown = 4,
+		emoji = "💰", title = "Unexpected Money!",
+		category = "social",
+		-- These sources don't require employment
+		getDynamicData = function()
+			local sources = {"winning a scratch-off", "old savings you forgot about", "a returned security deposit", "selling old stuff online", "a small inheritance from a distant relative"}
+			local amount = math.random(500, 5000)
 			return { source = sources[math.random(#sources)], amount = amount }
 		end,
 		text = "You received $%amount% from %source%! What do you do?",
 		choices = {
-			{ text = "💰 Save it all", effects = { Money = 15000, Happiness = 4, Smarts = 3 }, resultText = "Future you will thank present you!", setFlag = "saver" },
-			{ text = "💸 Spend it!", effects = { Money = 5000, Happiness = 10 }, resultText = "YOLO! Enjoyed every penny!" },
-			{ text = "📈 Invest it", effects = { Money = 8000, Smarts = 5 }, resultText = "Making money work for you!", setFlag = "investor" },
-			{ text = "💳 Pay off debt", effects = { Money = -2000, Happiness = 6, Smarts = 4 }, resultText = "Responsible choice! One step closer to financial freedom!", setFlag = "financially_responsible" },
+			{ text = "💰 Save it all", effects = { Money = 3000, Happiness = 4, Smarts = 3 }, resultText = "Every bit counts! Saved!", setFlag = "saver" },
+			{ text = "💸 Spend it!", effects = { Money = 1000, Happiness = 8 }, resultText = "Treat yourself! Life's short!" },
+			{ text = "📈 Invest it", effects = { Money = 2000, Smarts = 4 }, resultText = "Small investments add up!", setFlag = "investor" },
+			{ text = "💳 Pay a bill", effects = { Money = 1500, Happiness = 4, Smarts = 2 }, resultText = "Responsible choice!" },
 		},
 	},
 	
@@ -1235,8 +1295,30 @@ module.events = {
 		weight = 30, oneTime = true,
 		emoji = "🌟", title = "Academic Excellence Pays Off!",
 		category = "school",
-		requiresAnyFlag = {"honors_student", "honor_student", "valedictorian", "award_winner"},
+		-- CRITICAL: Must have ACTUAL academic achievements to trigger this event
+		-- Requires at least one of these flags that prove academic excellence
+		requiresAnyFlag = {"honors_student", "honor_student", "valedictorian", "award_winner", "deans_list", "honor_roll", "academic_achiever", "academic_focused", "high_test_scores", "scholarship"},
+		-- Block if never actually studied or dropped out
 		blockIfFlag = "high_school_dropout",
+		-- Also verify they actually have academic history
+		requires = function(state)
+			local flags = state.Flags or {}
+			-- Must not be a dropout without GED
+			if flags.high_school_dropout and not flags.ged_graduate then
+				return false
+			end
+			-- Must have at least graduated high school OR be a college student
+			local hasEducation = flags.high_school_graduate or flags.college_student or flags.college_graduate or flags.ged_graduate
+			if not hasEducation then
+				return false
+			end
+			-- Must have demonstrated academic excellence (not just attendance)
+			local hasAcademicExcellence = flags.honors_student or flags.honor_student or flags.valedictorian 
+				or flags.award_winner or flags.deans_list or flags.honor_roll 
+				or flags.academic_achiever or flags.academic_focused or flags.high_test_scores
+				or flags.scholarship or flags.dedicated_student
+			return hasAcademicExcellence
+		end,
 		text = "Your academic achievements caught someone's attention! A prestigious program wants you!",
 		choices = {
 			{ 

--- a/ReplicatedStorage/LifeStageSystem.lua
+++ b/ReplicatedStorage/LifeStageSystem.lua
@@ -555,6 +555,13 @@ function LifeStageSystem.getCapabilities(state)
 	local flags = state.Flags or {}
 
 	local inPrison = flags.in_prison or flags.incarcerated or state.InJail
+	
+	-- Check dropout/expelled status
+	local hasDroppedOut = flags.dropped_out or flags.expelled or flags.quit_school
+	
+	-- Determine if in school: must be in school-age stage AND not dropped out
+	-- OR be a college student (separate enrollment)
+	local inSchool = (stage.inSchool and not hasDroppedOut) or flags.college_student
 
 	return {
 		canWork = stage.canWork and age >= 14 and not inPrison,
@@ -569,8 +576,9 @@ function LifeStageSystem.getCapabilities(state)
 		canEnrollCollege = age >= 18 and age <= 50,
 		canRetire = age >= 50,
 
-		inSchool = stage.inSchool or flags.college_student,
+		inSchool = inSchool,
 		schoolType = flags.college_student and "university" or stage.schoolType,
+		hasDroppedOut = hasDroppedOut,
 
 		canStartPolitics = age >= 18 and flags.political_interest,
 		canStartRacing = age >= 16 and flags.racing_interest,
@@ -810,10 +818,17 @@ function LifeStageSystem.validateEvent(eventDef, state)
 
 	-- 12. School events require being in school or college
 	if eventDef.category == "school" and not caps.inPrison then
-		local inSchool = caps.inSchool or (age >= 5 and age <= 18)
-		if not inSchool and not flags.college_student then
+		-- Check dropout/expelled flags first - these block school events entirely
+		local hasDroppedOut = flags.dropped_out or flags.expelled or flags.quit_school
+		if hasDroppedOut and not flags.college_student then
 			result.valid = false
-			table.insert(result.reasons, "Not in school")
+			table.insert(result.reasons, "Dropped out of school")
+		else
+			local inSchool = caps.inSchool or (age >= 5 and age <= 18 and not hasDroppedOut)
+			if not inSchool and not flags.college_student then
+				result.valid = false
+				table.insert(result.reasons, "Not in school")
+			end
 		end
 	end
 
@@ -911,6 +926,23 @@ function LifeStageSystem.validateEvent(eventDef, state)
 				result.valid = false
 				table.insert(result.reasons, statName .. " too high (max " .. maxValue .. ", have " .. currentValue .. ")")
 			end
+		end
+	end
+
+	-- ═══════════════════════════════════════════════════════════════
+	-- 16. DYNAMIC DATA VALIDATION
+	-- If getDynamicData returns nil, the event cannot fire
+	-- This prevents events with missing required relationships from firing
+	-- ═══════════════════════════════════════════════════════════════
+	
+	if result.valid and eventDef.getDynamicData then
+		local ok, dynamicData = pcall(eventDef.getDynamicData, state)
+		if not ok then
+			result.valid = false
+			table.insert(result.reasons, "getDynamicData failed: " .. tostring(dynamicData))
+		elseif dynamicData == nil then
+			result.valid = false
+			table.insert(result.reasons, "getDynamicData returned nil (missing required data)")
 		end
 	end
 

--- a/ReplicatedStorage/LifeStageSystem.lua
+++ b/ReplicatedStorage/LifeStageSystem.lua
@@ -1,6 +1,7 @@
 -- LifeStageSystem.lua
 -- Comprehensive BitLife-style life stage management.
 -- Controls what events, actions, and content are available at each stage.
+-- INTEGRATED with EventMemory for AAA-quality validation
 
 local LifeStageSystem = {}
 
@@ -9,6 +10,19 @@ local LifeStageSystem = {}
 ----------------------------------------------------------------------
 
 local DEBUG_EVENT_VALIDATION = false
+
+-- Load EventMemory for comprehensive validation
+local EventMemory = nil
+local function loadEventMemory()
+	if EventMemory then return EventMemory end
+	local success, result = pcall(function()
+		return require(script.Parent:WaitForChild("EventMemory", 2))
+	end)
+	if success and result then
+		EventMemory = result
+	end
+	return EventMemory
+end
 
 local function dprint(...)
 	if DEBUG_EVENT_VALIDATION then
@@ -946,6 +960,105 @@ function LifeStageSystem.validateEvent(eventDef, state)
 		end
 	end
 
+	-- ═══════════════════════════════════════════════════════════════
+	-- 17. COMPREHENSIVE MEMORY-BASED VALIDATION (AAA BitLife-style)
+	-- Uses EventMemory to check player's ACTUAL history, not just flags
+	-- This prevents illogical events like "tax returns" for non-workers
+	-- ═══════════════════════════════════════════════════════════════
+	
+	if result.valid then
+		local mem = loadEventMemory()
+		if mem and state.Memory then
+			local memoryValidation = mem.validateEvent(eventDef, state, state.Memory)
+			if not memoryValidation.valid then
+				result.valid = false
+				for _, reason in ipairs(memoryValidation.reasons or {}) do
+					table.insert(result.reasons, "[Memory] " .. reason)
+				end
+			end
+		end
+		
+		-- Additional memory-specific checks using LifeState methods if available
+		if result.valid then
+			-- Work history checks
+			if eventDef.requiresWorkHistory then
+				local hasWorked = state.HasEverWorked and state:HasEverWorked() 
+					or flags.employed or flags.has_job or flags.ever_worked
+				if not hasWorked then
+					result.valid = false
+					table.insert(result.reasons, "Requires work history")
+				end
+			end
+			
+			if eventDef.requiresCurrentJob then
+				local employed = state.IsCurrentlyEmployed and state:IsCurrentlyEmployed()
+					or flags.employed or flags.has_job
+				if not employed then
+					result.valid = false
+					table.insert(result.reasons, "Requires current employment")
+				end
+			end
+			
+			-- Tax history (must have worked to file taxes)
+			if eventDef.requiresTaxHistory then
+				local canTax = state.CanFileTaxes and state:CanFileTaxes()
+					or flags.employed or flags.has_job or flags.ever_worked
+				if not canTax then
+					result.valid = false
+					table.insert(result.reasons, "Requires work/tax history")
+				end
+			end
+			
+			-- Friend requirements (must have actual friends)
+			if eventDef.requiresFriends then
+				local hasFriends = state.HasActualFriends and state:HasActualFriends()
+				if not hasFriends then
+					result.valid = false
+					table.insert(result.reasons, "Requires actual friends")
+				end
+			end
+			
+			-- Partner requirements
+			if eventDef.requiresPartner then
+				local hasPartner = state.HasRomanticPartner and state:HasRomanticPartner()
+					or flags.dating or flags.married or flags.in_relationship
+				if not hasPartner then
+					result.valid = false
+					table.insert(result.reasons, "Requires romantic partner")
+				end
+			end
+			
+			-- Block if dropout (for education-requiring events)
+			if eventDef.blocksDropout then
+				local isDropout = state.HasDroppedOut and state:HasDroppedOut()
+					or flags.dropped_out or flags.expelled
+				if isDropout then
+					result.valid = false
+					table.insert(result.reasons, "Blocked for school dropouts")
+				end
+			end
+			
+			-- Criminal history checks
+			if eventDef.requiresCriminalHistory then
+				local hasCrime = state.HasCriminalRecord and state:HasCriminalRecord()
+					or flags.criminal or flags.committed_crime
+				if not hasCrime then
+					result.valid = false
+					table.insert(result.reasons, "Requires criminal history")
+				end
+			end
+			
+			if eventDef.blocksIfCriminal then
+				local hasCrime = state.HasCriminalRecord and state:HasCriminalRecord()
+					or flags.criminal or flags.criminal_record
+				if hasCrime then
+					result.valid = false
+					table.insert(result.reasons, "Blocked by criminal record")
+				end
+			end
+		end
+	end
+
 	if DEBUG_EVENT_VALIDATION or eventDef.category == "prison" then
 		if result.valid then
 			dprint("✅ Event", eventDef.id, "PASSED validation")
@@ -1549,6 +1662,20 @@ end
 
 -- Check if player has EVER worked (any job, any time)
 function LifeStageSystem.hasEverWorked(state)
+	-- First check via LifeState method (uses Memory if available)
+	if state.HasEverWorked then
+		return state:HasEverWorked()
+	end
+	
+	-- Also check via EventMemory directly
+	local mem = loadEventMemory()
+	if mem and state.Memory then
+		if mem.hasEverWorked(state.Memory) then
+			return true
+		end
+	end
+	
+	-- Fallback to flags
 	local flags = state.Flags or {}
 	return flags.employed or flags.has_job or flags.career_starter 
 		or flags.ever_worked or flags.first_job or flags.good_worker 
@@ -1559,6 +1686,11 @@ end
 
 -- Check if player is CURRENTLY employed
 function LifeStageSystem.isCurrentlyEmployed(state)
+	-- First check via LifeState method (uses Memory if available)
+	if state.IsCurrentlyEmployed then
+		return state:IsCurrentlyEmployed()
+	end
+	
 	local flags = state.Flags or {}
 	return flags.employed or flags.has_job or flags.side_hustler
 end
@@ -1597,6 +1729,20 @@ end
 
 -- Check if player has any friends in relationships
 function LifeStageSystem.hasActualFriends(state)
+	-- First check via LifeState method (uses Memory if available)
+	if state.HasActualFriends then
+		return state:HasActualFriends()
+	end
+	
+	-- Check via EventMemory directly
+	local mem = loadEventMemory()
+	if mem and state.Memory then
+		if mem.hasFriends(state.Memory) then
+			return true
+		end
+	end
+	
+	-- Fallback to relationships check
 	local relationships = state.Relationships or {}
 	for _, rel in pairs(relationships) do
 		if (rel.type == "friend" or rel.category == "friends") and rel.alive ~= false then

--- a/ReplicatedStorage/LifeStageSystem.lua
+++ b/ReplicatedStorage/LifeStageSystem.lua
@@ -1542,4 +1542,93 @@ function LifeStageSystem.serializeForClient(state)
 	}
 end
 
+----------------------------------------------------------------------
+-- CENTRALIZED STATE VALIDATION HELPERS
+-- Use these in events to properly validate player history
+----------------------------------------------------------------------
+
+-- Check if player has EVER worked (any job, any time)
+function LifeStageSystem.hasEverWorked(state)
+	local flags = state.Flags or {}
+	return flags.employed or flags.has_job or flags.career_starter 
+		or flags.ever_worked or flags.first_job or flags.good_worker 
+		or flags.worked_parttime or flags.intern_experience 
+		or flags.internship_completed or flags.side_hustler
+		or flags.entrepreneur or flags.business_owner
+end
+
+-- Check if player is CURRENTLY employed
+function LifeStageSystem.isCurrentlyEmployed(state)
+	local flags = state.Flags or {}
+	return flags.employed or flags.has_job or flags.side_hustler
+end
+
+-- Check if player has completed high school (diploma or GED)
+function LifeStageSystem.hasHighSchoolEducation(state)
+	local flags = state.Flags or {}
+	-- Must not be a dropout without GED
+	if flags.high_school_dropout and not flags.ged_graduate then
+		return false
+	end
+	return flags.high_school_graduate or flags.ged_graduate or flags.college_student or flags.college_graduate
+end
+
+-- Check if player has college education
+function LifeStageSystem.hasCollegeEducation(state)
+	local flags = state.Flags or {}
+	return flags.college_graduate or flags.advanced_degree or flags.bachelors_degree
+		or flags.masters_degree or flags.doctorate or flags.phd
+end
+
+-- Check if player is currently in school (any level)
+function LifeStageSystem.isInSchool(state)
+	local caps = LifeStageSystem.getCapabilities(state)
+	return caps.inSchool
+end
+
+-- Check if player has demonstrated academic excellence
+function LifeStageSystem.hasAcademicExcellence(state)
+	local flags = state.Flags or {}
+	return flags.honors_student or flags.honor_student or flags.valedictorian 
+		or flags.award_winner or flags.deans_list or flags.honor_roll 
+		or flags.academic_achiever or flags.academic_focused or flags.high_test_scores
+		or flags.scholarship or flags.dedicated_student
+end
+
+-- Check if player has any friends in relationships
+function LifeStageSystem.hasActualFriends(state)
+	local relationships = state.Relationships or {}
+	for _, rel in pairs(relationships) do
+		if (rel.type == "friend" or rel.category == "friends") and rel.alive ~= false then
+			return true
+		end
+	end
+	return false
+end
+
+-- Check if player has romantic partner
+function LifeStageSystem.hasRomanticPartner(state)
+	local relationships = state.Relationships or {}
+	for _, rel in pairs(relationships) do
+		if (rel.type == "romance" or rel.category == "romance") and rel.alive ~= false then
+			return true
+		end
+	end
+	local flags = state.Flags or {}
+	return flags.in_relationship or flags.married or flags.dating or flags.engaged
+end
+
+-- Check if player can afford something (minimum money check)
+function LifeStageSystem.canAfford(state, amount)
+	return (state.Money or 0) >= amount
+end
+
+-- Check if player has any social history (for events about reconnecting, etc.)
+function LifeStageSystem.hasSocialHistory(state)
+	local flags = state.Flags or {}
+	return flags.ever_had_friend or flags.college_graduate or flags.high_school_diploma 
+		or flags.social_butterfly or flags.had_childhood_friend or flags.had_college_friends
+		or flags.good_roommate or flags.friendly or LifeStageSystem.hasActualFriends(state)
+end
+
 return LifeStageSystem

--- a/ReplicatedStorage/LifeState.lua
+++ b/ReplicatedStorage/LifeState.lua
@@ -1,9 +1,26 @@
 -- LifeState.lua
 -- Server-side representation of a player's life state with BitLife-style systems
 -- Extended with career paths, relationships, assets, and proper helpers
+-- INTEGRATED with EventMemory for comprehensive history tracking
 
 local LifeState = {}
 LifeState.__index = LifeState
+
+-- Load EventMemory module for comprehensive player history tracking
+local EventMemory = nil
+local function loadEventMemory()
+	if EventMemory then return EventMemory end
+	local success, result = pcall(function()
+		return require(script.Parent:WaitForChild("EventMemory", 2))
+	end)
+	if success and result then
+		EventMemory = result
+		print("[LifeState] EventMemory module loaded successfully")
+	else
+		warn("[LifeState] EventMemory module not found, using basic flag tracking")
+	end
+	return EventMemory
+end
 
 local function clamp(n, minVal, maxVal)
 	if n < minVal then
@@ -135,6 +152,18 @@ function LifeState.new(player)
 	-- Feed log
 	self.Feed = {}
 
+	-- ═══════════════════════════════════════════════════════════════
+	-- COMPREHENSIVE EVENT MEMORY (AAA BitLife-style history tracking)
+	-- This tracks EVERYTHING the player does for proper event validation
+	-- ═══════════════════════════════════════════════════════════════
+	local mem = loadEventMemory()
+	if mem then
+		self.Memory = mem.create()
+	else
+		-- Fallback if EventMemory module fails to load
+		self.Memory = nil
+	end
+
 	return self
 end
 
@@ -186,6 +215,149 @@ function LifeState:ApplyEffects(effects)
 	end
 
 	self:ClampStats()
+end
+
+----------------------------------------------------------------------
+-- EVENT MEMORY INTEGRATION (AAA BitLife-style tracking)
+----------------------------------------------------------------------
+
+-- Record an event to memory (call this when events occur)
+function LifeState:RecordEvent(eventType, data)
+	local mem = loadEventMemory()
+	if mem and self.Memory then
+		mem.recordEvent(self.Memory, eventType, data, self.Age)
+		-- Sync memory-derived flags to state flags
+		mem.syncToState(self.Memory, self)
+	end
+end
+
+-- Validate if an event can fire based on player's actual history
+function LifeState:ValidateEvent(eventDef)
+	local mem = loadEventMemory()
+	if mem and self.Memory then
+		return mem.validateEvent(eventDef, self, self.Memory)
+	end
+	return { valid = true, reasons = {} } -- Allow if no memory available
+end
+
+-- Get comprehensive life summary from memory
+function LifeState:GetLifeSummary()
+	local mem = loadEventMemory()
+	if mem and self.Memory then
+		return mem.getLifeSummary(self.Memory)
+	end
+	return {}
+end
+
+-- Memory-backed validation helpers (use these in events!)
+function LifeState:HasEverWorked()
+	local mem = loadEventMemory()
+	if mem and self.Memory then
+		return mem.hasEverWorked(self.Memory)
+	end
+	-- Fallback to flags
+	return self:HasFlag("employed") or self:HasFlag("has_job") or self:HasFlag("ever_worked")
+end
+
+function LifeState:IsCurrentlyEmployed()
+	local mem = loadEventMemory()
+	if mem and self.Memory then
+		return mem.isCurrentlyEmployed(self.Memory)
+	end
+	return self:HasFlag("employed") or self:HasFlag("has_job")
+end
+
+function LifeState:HasEducation(level)
+	local mem = loadEventMemory()
+	if mem and self.Memory then
+		return mem.hasEducation(self.Memory, level)
+	end
+	-- Fallback to Education table
+	local educationLevels = {
+		none = 0, elementary = 1, middle = 2, high_school = 3, highschool = 3,
+		some_college = 4, associate = 5, bachelor = 6, bachelors = 6,
+		master = 7, masters = 7, doctorate = 8, phd = 8,
+	}
+	local currentLevel = educationLevels[self.Education.level or "none"] or 0
+	local requiredLevel = educationLevels[level] or 0
+	return currentLevel >= requiredLevel
+end
+
+function LifeState:HasDroppedOut()
+	local mem = loadEventMemory()
+	if mem and self.Memory then
+		return mem.hasDroppedOut(self.Memory)
+	end
+	return self:HasFlag("dropped_out") or self:HasFlag("expelled")
+end
+
+function LifeState:HasActualFriends()
+	local mem = loadEventMemory()
+	if mem and self.Memory then
+		return mem.hasFriends(self.Memory)
+	end
+	-- Fallback to relationships
+	for _, rel in pairs(self.Relationships) do
+		if (rel.type == "friend") and rel.alive ~= false then
+			return true
+		end
+	end
+	return false
+end
+
+function LifeState:GetFriendName()
+	local mem = loadEventMemory()
+	if mem and self.Memory then
+		return mem.getFriendName(self.Memory)
+	end
+	-- Fallback to relationships
+	for _, rel in pairs(self.Relationships) do
+		if (rel.type == "friend") and rel.alive ~= false and rel.name then
+			return rel.name
+		end
+	end
+	return nil
+end
+
+function LifeState:HasRomanticPartner()
+	local mem = loadEventMemory()
+	if mem and self.Memory then
+		return mem.hasPartner(self.Memory)
+	end
+	local _, partner = self:GetPartner()
+	return partner ~= nil
+end
+
+function LifeState:HasCriminalRecord()
+	local mem = loadEventMemory()
+	if mem and self.Memory then
+		return mem.hasCriminalRecord(self.Memory)
+	end
+	return #self.CriminalRecord > 0 or self:HasFlag("criminal")
+end
+
+function LifeState:CanFileTaxes()
+	local mem = loadEventMemory()
+	if mem and self.Memory then
+		return mem.canFileTaxes(self.Memory)
+	end
+	return self:HasEverWorked()
+end
+
+function LifeState:HasSkill(skillName)
+	local mem = loadEventMemory()
+	if mem and self.Memory then
+		return mem.hasSkill(self.Memory, skillName)
+	end
+	return self:HasFlag("knows_" .. string.lower(skillName):gsub(" ", "_"))
+end
+
+function LifeState:HasLicense(licenseType)
+	local mem = loadEventMemory()
+	if mem and self.Memory then
+		return mem.hasLicense(self.Memory, licenseType)
+	end
+	return self:HasFlag("has_" .. licenseType .. "_license") or self:HasFlag("has_license")
 end
 
 ----------------------------------------------------------------------
@@ -351,6 +523,22 @@ function LifeState:AddRelationship(categoryOrType, person)
 	}
 	
 	self.Relationships[uniqueId] = entry
+	
+	-- RECORD TO MEMORY (AAA BitLife-style tracking)
+	if standardType == "friend" then
+		self:RecordEvent("made_friend", {
+			name = entry.name,
+			id = uniqueId,
+		})
+		self:SetFlag("ever_had_friend")
+		self:SetFlag("has_friend")
+	elseif standardType == "romance" then
+		self:RecordEvent("started_dating", {
+			partner = entry.name,
+			id = uniqueId,
+		})
+	end
+	
 	return entry, uniqueId
 end
 
@@ -444,9 +632,29 @@ function LifeState:SetCareer(path, title, employer, salary)
 	self.Job = employer
 	self.JobTitle = title
 	self.JobSalary = salary or 0
+	
+	-- Set employment flags
+	self:SetFlag("employed")
+	self:SetFlag("has_job")
+	self:SetFlag("ever_worked")
+	
+	-- RECORD TO MEMORY (AAA BitLife-style tracking)
+	self:RecordEvent("job_started", {
+		path = path,
+		title = title,
+		employer = employer,
+		salary = salary or 0,
+	})
 end
 
-function LifeState:ClearCareer()
+function LifeState:ClearCareer(reason)
+	local previousJob = {
+		path = self.Career.path,
+		title = self.Career.jobTitle,
+		employer = self.Career.employer,
+		salary = self.Career.salary,
+	}
+	
 	self.Career = {
 		path = nil,
 		jobTitle = nil,
@@ -459,6 +667,14 @@ function LifeState:ClearCareer()
 	self.Job = nil
 	self.JobTitle = nil
 	self.JobSalary = 0
+	
+	-- Clear employment flags
+	self:ClearFlag("employed")
+	self:ClearFlag("has_job")
+	
+	-- RECORD TO MEMORY
+	local eventType = reason == "fired" and "job_fired" or (reason == "quit" and "job_quit" or "job_ended")
+	self:RecordEvent(eventType, previousJob)
 end
 
 function LifeState:HasJob()
@@ -496,6 +712,29 @@ function LifeState:Graduate(degree)
 			major = self.Education.major,
 		})
 	end
+	
+	-- RECORD TO MEMORY (AAA BitLife-style tracking)
+	self:RecordEvent("school_graduated", {
+		level = self.Education.level,
+		degree = degree,
+		schoolName = self.Education.schoolName,
+		major = self.Education.major,
+	})
+	
+	-- Set appropriate flags
+	if self.Education.level == "highschool" or self.Education.level == "high_school" then
+		self:SetFlag("high_school_graduate")
+	elseif self.Education.level == "university" or self.Education.level == "bachelor" then
+		self:SetFlag("college_graduate")
+		self:SetFlag("bachelors_degree")
+	elseif self.Education.level == "graduate" or self.Education.level == "master" then
+		self:SetFlag("masters_degree")
+		self:SetFlag("advanced_degree")
+	elseif self.Education.level == "doctorate" then
+		self:SetFlag("doctorate")
+		self:SetFlag("phd")
+		self:SetFlag("advanced_degree")
+	end
 end
 
 function LifeState:HasDegree(degreeType)
@@ -505,6 +744,40 @@ function LifeState:HasDegree(degreeType)
 		end
 	end
 	return false
+end
+
+function LifeState:DropOut(level)
+	local dropoutLevel = level or self.Education.level
+	
+	-- Set flags
+	self:SetFlag("dropped_out")
+	if dropoutLevel == "highschool" or dropoutLevel == "high_school" then
+		self:SetFlag("high_school_dropout")
+	end
+	
+	-- RECORD TO MEMORY (AAA BitLife-style tracking)
+	self:RecordEvent("school_dropped_out", {
+		level = dropoutLevel,
+	})
+end
+
+function LifeState:GetGED()
+	self:SetFlag("ged_graduate")
+	self:ClearFlag("high_school_dropout") -- GED removes dropout stigma
+	
+	-- RECORD TO MEMORY
+	self:RecordEvent("got_ged", {})
+end
+
+function LifeState:Expelled()
+	self:SetFlag("expelled")
+	self:SetFlag("dropped_out")
+	
+	-- RECORD TO MEMORY
+	self:RecordEvent("school_dropped_out", {
+		level = self.Education.level,
+		reason = "expelled",
+	})
 end
 
 ----------------------------------------------------------------------
@@ -898,23 +1171,40 @@ end
 -- CRIMINAL RECORD
 ----------------------------------------------------------------------
 
-function LifeState:AddCrime(crime)
+function LifeState:AddCrime(crime, caught)
 	table.insert(self.CriminalRecord, {
 		crime = crime,
 		year = self.Year,
 		age = self.Age,
+		caught = caught or false,
 	})
+	
+	-- RECORD TO MEMORY (AAA BitLife-style tracking)
+	self:RecordEvent("committed_crime", {
+		type = crime,
+		caught = caught or false,
+	})
+	self:SetFlag("criminal")
+	self:SetFlag("committed_crime")
 end
 
 function LifeState:HasCriminalRecord()
 	return #self.CriminalRecord > 0
 end
 
-function LifeState:GoToJail(years)
+function LifeState:GoToJail(years, crime)
 	self.InJail = true
 	self.JailSentence = years
 	self.JailTime = years
 	self:SetFlag("in_prison")
+	self:SetFlag("criminal_record")
+	
+	-- RECORD TO MEMORY (AAA BitLife-style tracking)
+	self:RecordEvent("arrested", { crime = crime })
+	self:RecordEvent("went_to_prison", {
+		years = years,
+		crime = crime,
+	})
 end
 
 function LifeState:ServeTime(years)
@@ -926,6 +1216,10 @@ function LifeState:ServeTime(years)
 		self.JailTime = 0
 		self:ClearFlag("in_prison")
 		self:SetFlag("ex_con")
+		
+		-- RECORD TO MEMORY (AAA BitLife-style tracking)
+		self:RecordEvent("released_from_prison", {})
+		
 		return true  -- Released
 	end
 	return false
@@ -1189,6 +1483,9 @@ function LifeState:Serialize()
 		
 		-- Feed log (recent entries only to save space)
 		Feed = self:GetRecentFeed(50),
+		
+		-- Comprehensive Event Memory (AAA BitLife-style tracking)
+		Memory = self.Memory,
 	}
 end
 
@@ -1299,6 +1596,17 @@ function LifeState.fromSerialized(player, data)
 	
 	-- Feed
 	self.Feed = data.Feed or {}
+	
+	-- Restore Event Memory (AAA BitLife-style tracking)
+	local mem = loadEventMemory()
+	if mem and data.Memory then
+		self.Memory = data.Memory
+	elseif mem then
+		-- Create fresh memory if no saved data
+		self.Memory = mem.create()
+	else
+		self.Memory = nil
+	end
 	
 	return self
 end


### PR DESCRIPTION
Corrects teen event category and driving license flags, enforces dropout event blocking, and prevents "phantom friend" events by validating dynamic data and relationship existence.

Teen job/internship events were using a category ('career') not recognized by the TEEN stage, preventing them from firing. The driver's license event set an incorrect flag ('can_drive' instead of 'has_license'), which broke driving capabilities. School events could still appear for dropped-out players. The "Alex asking for advice" bug, where events implied an existing relationship but used a random name, is fixed by ensuring events only fire when a valid relationship exists and by rejecting events if their dynamic data (e.g., a friend's name) is missing.

---
<a href="https://cursor.com/background-agent?bcId=bc-b0f8fdd5-7d02-41f3-a532-51759a0581b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-b0f8fdd5-7d02-41f3-a532-51759a0581b2"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

